### PR TITLE
Fix phone input types and error messages

### DIFF
--- a/src/components/ContactForm/ContactForm.jsx
+++ b/src/components/ContactForm/ContactForm.jsx
@@ -59,7 +59,7 @@ function ContactForm() {
             setIsDirty(false);
             handleSubmit();
           } else {
-            throw new Error('������ ��� �������� ������ �� ������');
+            throw new Error('Failed to submit form');
           }
         })
         .catch((error) => alert(error));
@@ -113,7 +113,7 @@ function ContactForm() {
           <label>
             <span>{t('contactModal.phoneNumber')}</span>
             <input
-              type="number"
+              type="tel"
               className={s.contactInput}
               autoComplete="off"
               name="phone"

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -63,7 +63,7 @@ function Modal({ isModalOpen, setIsModalOpen }) {
             setIsDirty(false);
             handleSubmit();
           } else {
-            throw new Error('������ ��� �������� ������ �� ������');
+            throw new Error('Failed to submit form');
           }
         })
         .catch((error) => alert(error));
@@ -128,7 +128,7 @@ function Modal({ isModalOpen, setIsModalOpen }) {
                 <span>{t('contactModal.phoneNumber')}</span>
                 <input
                   required
-                  type="number"
+                  type="tel"
                   autoComplete="off"
                   className={s.contactInput}
                   name="phone"


### PR DESCRIPTION
## Summary
- fix broken error messages in form submit handlers
- use `tel` input type for phone numbers

## Testing
- `grep -R "Failed to submit form" -n`


------
https://chatgpt.com/codex/tasks/task_e_68404f5c0b34832db80cedfa73f65ef7